### PR TITLE
Allow input/output arguments, PDF rendering.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 **/*.rs.bk
 tmp/**
+output.pdf

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 **/*.rs.bk
+tmp/**

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,6 +1,48 @@
 [[package]]
+name = "ansi_term"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "atty"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
+ "termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "bitflags"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "byteorder"
 version = "1.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "clap"
+version = "2.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -8,7 +50,88 @@ name = "lines-are-rusty"
 version = "0.1.0"
 dependencies = [
  "byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
+[[package]]
+name = "redox_syscall"
+version = "0.1.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "redox_termios"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "redox_syscall 0.1.54 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "strsim"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "termion"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.54 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "vec_map"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
 [metadata]
+"checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
+"checksum atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9a7d5b8723950951411ee34d271d99dddcc2035a16ab25310ea2c8cfd4369652"
+"checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
 "checksum byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "90492c5858dd7d2e78691cfb89f90d273a2800fc11d98f60786e5d87e2f83781"
+"checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
+"checksum libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)" = "bedcc7a809076656486ffe045abeeac163da1b558e963a31e29fbfbeba916917"
+"checksum redox_syscall 0.1.54 (registry+https://github.com/rust-lang/crates.io-index)" = "12229c14a0f65c4f1cb046a3b52047cdd9da1f4b30f8a39c5063c8bae515e252"
+"checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
+"checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+"checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
+"checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+"checksum unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "882386231c45df4700b275c7ff55b6f3698780a650026380e72dabe76fa46526"
+"checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
+"checksum winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "f10e386af2b13e47c89e7236a7a14a086791a2b88ebad6df9bf42040195cf770"
+"checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+"checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,6 +41,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "libc"
 version = "0.2.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -51,6 +56,16 @@ version = "0.1.0"
 dependencies = [
  "byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pdf-canvas 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "pdf-canvas"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -90,6 +105,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.1.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.54 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "unicode-width"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -124,12 +149,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
 "checksum byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "90492c5858dd7d2e78691cfb89f90d273a2800fc11d98f60786e5d87e2f83781"
 "checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
+"checksum lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
 "checksum libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)" = "bedcc7a809076656486ffe045abeeac163da1b558e963a31e29fbfbeba916917"
+"checksum pdf-canvas 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9a9885dffef3197790f4975c5f6d2a915914eaab7dbc98b95f44025c11ba87e6"
 "checksum redox_syscall 0.1.54 (registry+https://github.com/rust-lang/crates.io-index)" = "12229c14a0f65c4f1cb046a3b52047cdd9da1f4b30f8a39c5063c8bae515e252"
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 "checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
 "checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+"checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
 "checksum unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "882386231c45df4700b275c7ff55b6f3698780a650026380e72dabe76fa46526"
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 "checksum winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "f10e386af2b13e47c89e7236a7a14a086791a2b88ebad6df9bf42040195cf770"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,8 @@
 name = "lines-are-rusty"
 version = "0.1.0"
 authors = ["Axel Huebl <axel.huebl@plasma.ninja>"]
+edition = "2018"
 
 [dependencies]
 byteorder = "*"
+clap = "*"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,5 +5,6 @@ authors = ["Axel Huebl <axel.huebl@plasma.ninja>"]
 edition = "2018"
 
 [dependencies]
-byteorder = "*"
-clap = "*"
+byteorder = "1.2"
+clap = "2"
+pdf-canvas = "0.6"

--- a/README.md
+++ b/README.md
@@ -4,3 +4,6 @@ Re-implementation of https://github.com/ax3l/lines-are-beautiful in Rust.
 
 Very, very early version.
 Just for the fun of it.
+
+File format:
+https://plasma.ninja/blog/devices/remarkable/binary/format/2017/12/26/reMarkable-lines-file-format.html

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,195 @@
+use byteorder::{LittleEndian, ReadBytesExt};
+use clap::{App, Arg};
+use std::fs::File;
+use std::io::Cursor;
+use std::io::Read;
+
+#[derive(Default)]
+pub struct Page {
+    layers: Vec<Layer>,
+}
+
+#[derive(Default)]
+pub struct Layer {
+    lines: Vec<Line>,
+}
+
+#[derive(Default)]
+pub struct Line {
+    brush_type: i32,
+    color: i32,
+    unknown_line_attribute: i32,
+    brush_base_size: f32,
+    points: Vec<Point>,
+}
+
+impl Line {
+    pub fn new(t: (i32, i32, i32, f32), pts: Vec<Point>) -> Line {
+        Line {
+            brush_type: t.0,
+            color: t.1,
+            unknown_line_attribute: t.2,
+            brush_base_size: t.3,
+            points: pts,
+        }
+    }
+}
+
+#[derive(Default)]
+pub struct Point {
+    x: f32,
+    y: f32,
+    speed: f32,
+    direction: f32,
+    width: f32,
+    pressure: f32,
+}
+
+impl Point {
+    pub fn new(f: (f32, f32, f32, f32, f32, f32)) -> Point {
+        Point {
+            x: f.0,
+            y: f.1,
+            speed: f.2,
+            direction: f.3,
+            width: f.4,
+            pressure: f.5,
+        }
+    }
+}
+
+#[test]
+fn test_read_number_i32() {
+    let num = read_number_i32(&[42, 0, 0, 0]);
+    assert_eq!(42, num);
+}
+
+pub fn read_number_i32(bytes: &[u8]) -> i32 {
+    let mut rdr = Cursor::new(&bytes[0..4]);
+    // TODO implement if let Some(...)
+    let number = rdr.read_i32::<LittleEndian>().unwrap();
+    number
+}
+
+pub fn read_number_f32(bytes: &[u8]) -> f32 {
+    let mut rdr = Cursor::new(&bytes[0..4]);
+    // TODO implement if let Some(...)
+    let number = rdr.read_f32::<LittleEndian>().unwrap();
+    number
+}
+
+pub fn parse_line_header(four_bytes: &mut std::slice::Chunks<u8>) -> Option<(i32, i32, i32, f32)> {
+    // let mut four_bytes = chunk.clone();
+    if let Some(brush_type) = four_bytes.next() {
+        if let Some(color) = four_bytes.next() {
+            if let Some(unknown_line_attribute) = four_bytes.next() {
+                if let Some(brush_base_size) = four_bytes.next() {
+                    // TODO verify range of values
+                    return Some((
+                        read_number_i32(brush_type),
+                        read_number_i32(color),
+                        read_number_i32(unknown_line_attribute),
+                        read_number_f32(brush_base_size),
+                    ));
+                }
+            }
+        }
+    }
+    None
+}
+
+pub fn parse_point_header(
+    four_bytes: &mut std::slice::Chunks<u8>,
+) -> Option<(f32, f32, f32, f32, f32, f32)> {
+    // let mut four_bytes = chunk.clone();
+    if let Some(x) = four_bytes.next() {
+        if let Some(y) = four_bytes.next() {
+            if let Some(speed) = four_bytes.next() {
+                if let Some(direction) = four_bytes.next() {
+                    if let Some(width) = four_bytes.next() {
+                        if let Some(pressure) = four_bytes.next() {
+                            // TODO verify range of values
+                            return Some((
+                                read_number_f32(x),
+                                read_number_f32(y),
+                                read_number_f32(speed),
+                                read_number_f32(direction),
+                                read_number_f32(width),
+                                read_number_f32(pressure),
+                            ));
+                        }
+                    }
+                }
+            }
+        }
+    }
+    None
+}
+
+pub fn read_points(four_bytes: &mut std::slice::Chunks<u8>, _max_size_file: usize) -> Vec<Point> {
+    let mut points = Vec::<Point>::default();
+    // let mut four_bytes = chunk.clone();
+
+    if let Some(num_points) = four_bytes.next() {
+        for _pt in 0..read_number_i32(num_points) {
+            println!("pt: {} / {}", _pt, read_number_i32(num_points));
+            if let Some(tuple) = parse_point_header(four_bytes) {
+                let new_point = Point::new(tuple);
+                points.push(new_point);
+            } else {
+                break;
+            }
+        }
+    }
+    points
+}
+
+pub fn read_lines(four_bytes: &mut std::slice::Chunks<u8>, _max_size_file: usize) -> Vec<Line> {
+    let mut lines = Vec::<Line>::default();
+    // let mut four_bytes = chunk.clone();
+
+    if let Some(num_lines) = four_bytes.next() {
+        for _li in 0..read_number_i32(num_lines) {
+            println!("li: {} / {}", _li, read_number_i32(num_lines));
+            if let Some(tuple) = parse_line_header(four_bytes) {
+                println!("new line!");
+                let new_line = Line::new(tuple, read_points(four_bytes, _max_size_file));
+                lines.push(new_line);
+                println!("new line done!");
+            } else {
+                break;
+            }
+        }
+    }
+    lines
+}
+
+pub fn read_layers(four_bytes: &mut std::slice::Chunks<u8>, _max_size_file: usize) -> Vec<Layer> {
+    let mut layers = Vec::<Layer>::default();
+    // let mut four_bytes = chunk.clone();
+
+    if let Some(num_layers) = four_bytes.next() {
+        for _l in 0..read_number_i32(num_layers) {
+            println!("l: {} / {}", _l, read_number_i32(num_layers));
+            let new_layer = Layer {
+                lines: read_lines(four_bytes, _max_size_file),
+            };
+            layers.push(new_layer);
+        }
+    }
+    layers
+}
+
+// bytes: &[u8]
+pub fn read_pages(four_bytes: &mut std::slice::Chunks<u8>, _max_size_file: usize) -> Vec<Page> {
+    let mut pages = Vec::<Page>::default();
+    // let mut four_bytes = chunk.clone();
+
+    let num_pages = 1;
+    println!("p: 0 / {}", num_pages);
+    let new_page = Page {
+        layers: read_layers(four_bytes, _max_size_file),
+    };
+    pages.push(new_page);
+    pages
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,18 +1,19 @@
 pub mod parse;
+pub mod render;
 
 pub use self::parse::*;
 
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct Page {
     pub layers: Vec<Layer>,
 }
 
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct Layer {
     pub lines: Vec<Line>,
 }
 
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct Line {
     pub brush_type: i32,
     pub color: i32,
@@ -33,7 +34,7 @@ impl Line {
     }
 }
 
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct Point {
     pub x: f32,
     pub y: f32,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,26 +1,24 @@
-#![allow(dead_code)]
+pub mod parse;
 
-use byteorder::{LittleEndian, ReadBytesExt};
-use std::io::Cursor;
-use std::io::Read;
+pub use self::parse::*;
 
 #[derive(Default)]
 pub struct Page {
-    layers: Vec<Layer>,
+    pub layers: Vec<Layer>,
 }
 
 #[derive(Default)]
 pub struct Layer {
-    lines: Vec<Line>,
+    pub lines: Vec<Line>,
 }
 
 #[derive(Default)]
 pub struct Line {
-    brush_type: i32,
-    color: i32,
-    unknown_line_attribute: i32,
-    brush_base_size: f32,
-    points: Vec<Point>,
+    pub brush_type: i32,
+    pub color: i32,
+    pub unknown_line_attribute: i32,
+    pub brush_base_size: f32,
+    pub points: Vec<Point>,
 }
 
 impl Line {
@@ -37,12 +35,12 @@ impl Line {
 
 #[derive(Default)]
 pub struct Point {
-    x: f32,
-    y: f32,
-    speed: f32,
-    direction: f32,
-    width: f32,
-    pressure: f32,
+    pub x: f32,
+    pub y: f32,
+    pub speed: f32,
+    pub direction: f32,
+    pub width: f32,
+    pub pressure: f32,
 }
 
 impl Point {
@@ -56,134 +54,4 @@ impl Point {
             pressure: f.5,
         }
     }
-}
-
-#[test]
-fn test_read_number_i32() {
-    let num = read_number_i32(&[42, 0, 0, 0]);
-    assert_eq!(42, num);
-}
-
-pub fn read_number_i32(bytes: &[u8]) -> i32 {
-    let mut rdr = Cursor::new(&bytes[0..4]);
-    // TODO implement if let Some(...)
-    let number = rdr.read_i32::<LittleEndian>().unwrap();
-    number
-}
-
-pub fn read_number_f32(bytes: &[u8]) -> f32 {
-    let mut rdr = Cursor::new(&bytes[0..4]);
-    // TODO implement if let Some(...)
-    let number = rdr.read_f32::<LittleEndian>().unwrap();
-    number
-}
-
-pub fn parse_line_header(cursor: &mut Cursor<&[u8]>) -> Option<(i32, i32, i32, f32)> {
-    let mut brush_type = [0u8; 4];
-    let mut color = [0u8; 4];
-    let mut unknown_line_attribute = [0u8; 4];
-    let mut brush_base_size = [0u8; 4];
-
-    cursor.read_exact(&mut brush_type).ok()?;
-    cursor.read_exact(&mut color).ok()?;
-    cursor.read_exact(&mut unknown_line_attribute).ok()?;
-    cursor.read_exact(&mut brush_base_size).ok()?;
-
-    // TODO verify range of values
-    return Some((
-        read_number_i32(&brush_type),
-        read_number_i32(&color),
-        read_number_i32(&unknown_line_attribute),
-        read_number_f32(&brush_base_size),
-    ));
-}
-
-pub fn parse_point_header(cursor: &mut Cursor<&[u8]>) -> Option<(f32, f32, f32, f32, f32, f32)> {
-    let mut x = [0u8; 4];
-    let mut y = [0u8; 4];
-    let mut speed = [0u8; 4];
-    let mut direction = [0u8; 4];
-    let mut width = [0u8; 4];
-    let mut pressure = [0u8; 4];
-
-    cursor.read_exact(&mut x).ok()?;
-    cursor.read_exact(&mut y).ok()?;
-    cursor.read_exact(&mut speed).ok()?;
-    cursor.read_exact(&mut direction).ok()?;
-    cursor.read_exact(&mut width).ok()?;
-    cursor.read_exact(&mut pressure).ok()?;
-
-    return Some((
-        read_number_f32(&x),
-        read_number_f32(&y),
-        read_number_f32(&speed),
-        read_number_f32(&direction),
-        read_number_f32(&width),
-        read_number_f32(&pressure),
-    ));
-}
-
-pub fn read_points(cursor: &mut Cursor<&[u8]>, _max_size_file: usize) -> Vec<Point> {
-    let mut points = Vec::<Point>::default();
-    let mut num_points = [0u8; 4];
-    if let Ok(()) = cursor.read_exact(&mut num_points) {
-        for _pt in 0..read_number_i32(&num_points) {
-            println!("pt: {} / {}", _pt, read_number_i32(&num_points));
-            if let Some(tuple) = parse_point_header(cursor) {
-                let new_point = Point::new(tuple);
-                points.push(new_point);
-            } else {
-                break;
-            }
-        }
-    }
-    points
-}
-
-pub fn read_lines(cursor: &mut Cursor<&[u8]>, _max_size_file: usize) -> Vec<Line> {
-    let mut lines = vec![];
-    let mut num_lines = [0u8; 4];
-    if let Ok(()) = cursor.read_exact(&mut num_lines) {
-        for _li in 0..read_number_i32(&num_lines) {
-            println!("li: {} / {}", _li, read_number_i32(&num_lines));
-            if let Some(tuple) = parse_line_header(cursor) {
-                println!("new line!");
-                let new_line = Line::new(tuple, read_points(cursor, _max_size_file));
-                lines.push(new_line);
-                println!("new line done!");
-            } else {
-                break;
-            }
-        }
-    }
-    lines
-}
-
-pub fn read_layers(cursor: &mut Cursor<&[u8]>, _max_size_file: usize) -> Vec<Layer> {
-    let mut layers = vec![];
-    let mut num_layers = [0u8; 4];
-    if let Ok(()) = cursor.read_exact(&mut num_layers) {
-        for _l in 0..read_number_i32(&num_layers) {
-            println!("l: {} / {}", _l, read_number_i32(&num_layers));
-            let new_layer = Layer {
-                lines: read_lines(cursor, _max_size_file),
-            };
-            layers.push(new_layer);
-        }
-    }
-    layers
-}
-
-// bytes: &[u8]
-pub fn read_pages(content: &[u8], _max_size_file: usize) -> Vec<Page> {
-    let mut cursor = Cursor::new(content);
-
-    let mut pages = vec![];
-    let num_pages = 1;
-    println!("p: 0 / {}", num_pages);
-    let new_page = Page {
-        layers: read_layers(&mut cursor, _max_size_file),
-    };
-    pages.push(new_page);
-    pages
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ use clap::{App, Arg};
 use std::fs::File;
 use std::io::Read;
 use lines_are_rusty::*;
+use lines_are_rusty::render::*;
 
 fn main() {
     let matches = App::new("lines-are-rusty")
@@ -14,12 +15,21 @@ fn main() {
                 .required(true)
                 .index(1),
         )
+        .arg(
+            Arg::with_name("output")
+                .help("The file to save the PDF to")
+                .required(true)
+                .index(2),
+        )
         .get_matches();
-
-    // Load the file into a Vec<u8>
     let filename = matches
         .value_of("file")
         .expect("Expected required filename.");
+    let output_filename = matches
+        .value_of("output")
+        .expect("Expected required filename.");
+
+    // Load the file into a Vec<u8>
     let mut f = File::open(filename).unwrap();
     let mut line_file = Vec::<u8>::new();
     f.read_to_end(&mut line_file).unwrap();
@@ -35,4 +45,6 @@ fn main() {
     let pages = read_pages(&content, max_size_file);
 
     println!("\ndone. read {} pages.", pages.len());
+
+    render(&output_filename, &pages);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,8 @@
-// until rust 2018
-extern crate byteorder;
-
 use std::io::Cursor;
 use byteorder::{LittleEndian, ReadBytesExt};
-
+use clap::{App, Arg};
+use std::fs::File;
+use std::io::Read;
 
 #[derive(Default)]
 struct Page {
@@ -194,8 +193,22 @@ fn read_pages(four_bytes: & mut std::slice::Chunks<u8>, _max_size_file: usize) -
 
 
 fn main() {
+    let matches = App::new("lines-are-rusty")
+       .version("0.1")
+       .about("Converts lines files from .rm to SVG.")
+       .author("Axel Huebl <axel.huebl@plasma.ninja>")
+       .arg(Arg::with_name("file")
+            .help("The file to read from")
+            .required(true)
+            .index(1))
+       .get_matches();
+    
+    let filename = matches.value_of("file").expect("Expected required filename.");
+    let mut f = File::open(filename).unwrap();
+    let mut line_file = Vec::new();
+    f.read_to_end(&mut line_file).unwrap();
+
     let max_size_file = 1024 * 1024; // Bytes
-    let line_file = include_bytes!("../aa90b0e7-5c1a-42fe-930f-dad9cf3363cc/0.rm");
     assert!(max_size_file >= line_file.len());
 
     // print!("{}", String::from_utf8_lossy(line_file));

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,193 +3,7 @@ use clap::{App, Arg};
 use std::fs::File;
 use std::io::Cursor;
 use std::io::Read;
-
-#[derive(Default)]
-struct Page {
-    layers: Vec<Layer>,
-}
-
-#[derive(Default)]
-struct Layer {
-    lines: Vec<Line>,
-}
-
-#[derive(Default)]
-struct Line {
-    brush_type: i32,
-    color: i32,
-    unknown_line_attribute: i32,
-    brush_base_size: f32,
-    points: Vec<Point>,
-}
-impl Line {
-    fn new(t: (i32, i32, i32, f32), pts: Vec<Point>) -> Line {
-        Line {
-            brush_type: t.0,
-            color: t.1,
-            unknown_line_attribute: t.2,
-            brush_base_size: t.3,
-            points: pts,
-        }
-    }
-}
-
-#[derive(Default)]
-struct Point {
-    x: f32,
-    y: f32,
-    speed: f32,
-    direction: f32,
-    width: f32,
-    pressure: f32,
-}
-impl Point {
-    fn new(f: (f32, f32, f32, f32, f32, f32)) -> Point {
-        Point {
-            x: f.0,
-            y: f.1,
-            speed: f.2,
-            direction: f.3,
-            width: f.4,
-            pressure: f.5,
-        }
-    }
-}
-
-#[test]
-fn test_read_number_i32() {
-    let num = read_number_i32(&[42, 0, 0, 0]);
-    assert_eq!(42, num);
-}
-fn read_number_i32(bytes: &[u8]) -> i32 {
-    let mut rdr = Cursor::new(&bytes[0..4]);
-    // TODO implement if let Some(...)
-    let number = rdr.read_i32::<LittleEndian>().unwrap();
-    number
-}
-
-fn read_number_f32(bytes: &[u8]) -> f32 {
-    let mut rdr = Cursor::new(&bytes[0..4]);
-    // TODO implement if let Some(...)
-    let number = rdr.read_f32::<LittleEndian>().unwrap();
-    number
-}
-
-fn parse_line_header(four_bytes: &mut std::slice::Chunks<u8>) -> Option<(i32, i32, i32, f32)> {
-    // let mut four_bytes = chunk.clone();
-    if let Some(brush_type) = four_bytes.next() {
-        if let Some(color) = four_bytes.next() {
-            if let Some(unknown_line_attribute) = four_bytes.next() {
-                if let Some(brush_base_size) = four_bytes.next() {
-                    // TODO verify range of values
-                    return Some((
-                        read_number_i32(brush_type),
-                        read_number_i32(color),
-                        read_number_i32(unknown_line_attribute),
-                        read_number_f32(brush_base_size),
-                    ));
-                }
-            }
-        }
-    }
-    None
-}
-
-fn parse_point_header(
-    four_bytes: &mut std::slice::Chunks<u8>,
-) -> Option<(f32, f32, f32, f32, f32, f32)> {
-    // let mut four_bytes = chunk.clone();
-    if let Some(x) = four_bytes.next() {
-        if let Some(y) = four_bytes.next() {
-            if let Some(speed) = four_bytes.next() {
-                if let Some(direction) = four_bytes.next() {
-                    if let Some(width) = four_bytes.next() {
-                        if let Some(pressure) = four_bytes.next() {
-                            // TODO verify range of values
-                            return Some((
-                                read_number_f32(x),
-                                read_number_f32(y),
-                                read_number_f32(speed),
-                                read_number_f32(direction),
-                                read_number_f32(width),
-                                read_number_f32(pressure),
-                            ));
-                        }
-                    }
-                }
-            }
-        }
-    }
-    None
-}
-
-fn read_points(four_bytes: &mut std::slice::Chunks<u8>, _max_size_file: usize) -> Vec<Point> {
-    let mut points = Vec::<Point>::default();
-    // let mut four_bytes = chunk.clone();
-
-    if let Some(num_points) = four_bytes.next() {
-        for _pt in 0..read_number_i32(num_points) {
-            println!("pt: {} / {}", _pt, read_number_i32(num_points));
-            if let Some(tuple) = parse_point_header(four_bytes) {
-                let new_point = Point::new(tuple);
-                points.push(new_point);
-            } else {
-                break;
-            }
-        }
-    }
-    points
-}
-
-fn read_lines(four_bytes: &mut std::slice::Chunks<u8>, _max_size_file: usize) -> Vec<Line> {
-    let mut lines = Vec::<Line>::default();
-    // let mut four_bytes = chunk.clone();
-
-    if let Some(num_lines) = four_bytes.next() {
-        for _li in 0..read_number_i32(num_lines) {
-            println!("li: {} / {}", _li, read_number_i32(num_lines));
-            if let Some(tuple) = parse_line_header(four_bytes) {
-                println!("new line!");
-                let new_line = Line::new(tuple, read_points(four_bytes, _max_size_file));
-                lines.push(new_line);
-                println!("new line done!");
-            } else {
-                break;
-            }
-        }
-    }
-    lines
-}
-
-fn read_layers(four_bytes: &mut std::slice::Chunks<u8>, _max_size_file: usize) -> Vec<Layer> {
-    let mut layers = Vec::<Layer>::default();
-    // let mut four_bytes = chunk.clone();
-
-    if let Some(num_layers) = four_bytes.next() {
-        for _l in 0..read_number_i32(num_layers) {
-            println!("l: {} / {}", _l, read_number_i32(num_layers));
-            let new_layer = Layer {
-                lines: read_lines(four_bytes, _max_size_file),
-            };
-            layers.push(new_layer);
-        }
-    }
-    layers
-}
-
-// bytes: &[u8]
-fn read_pages(four_bytes: &mut std::slice::Chunks<u8>, _max_size_file: usize) -> Vec<Page> {
-    let mut pages = Vec::<Page>::default();
-    // let mut four_bytes = chunk.clone();
-
-    let num_pages = 1;
-    println!("p: 0 / {}", num_pages);
-    let new_page = Page {
-        layers: read_layers(four_bytes, _max_size_file),
-    };
-    pages.push(new_page);
-    pages
-}
+use lines_are_rusty::*;
 
 fn main() {
     let matches = App::new("lines-are-rusty")
@@ -204,11 +18,12 @@ fn main() {
         )
         .get_matches();
 
+    // Load the file into a Vec<u8>
     let filename = matches
         .value_of("file")
         .expect("Expected required filename.");
     let mut f = File::open(filename).unwrap();
-    let mut line_file = Vec::new();
+    let mut line_file = Vec::<u8>::new();
     f.read_to_end(&mut line_file).unwrap();
 
     let max_size_file = 1024 * 1024; // Bytes

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,5 @@
-use byteorder::{LittleEndian, ReadBytesExt};
 use clap::{App, Arg};
 use std::fs::File;
-use std::io::Cursor;
 use std::io::Read;
 use lines_are_rusty::*;
 
@@ -26,32 +24,15 @@ fn main() {
     let mut line_file = Vec::<u8>::new();
     f.read_to_end(&mut line_file).unwrap();
 
-    let max_size_file = 1024 * 1024; // Bytes
+    let max_size_file = 1024 * 1024; // 1mb, or 1024 kilobytes
     assert!(max_size_file >= line_file.len());
 
-    // print!("{}", String::from_utf8_lossy(line_file));
+    // Assert fixed header.
+    assert_eq!(&line_file[0..33], "reMarkable .lines file, version=3".as_bytes());
 
-    let header = line_file.iter().take(33).cloned().collect::<Vec<u8>>();
-    assert_eq!(header, "reMarkable .lines file, version=3".as_bytes());
+    // Read document content.
+    let content = &line_file[43..];
+    let pages = read_pages(&content, max_size_file);
 
-    let mut numbers = line_file[43..].chunks(4);
-    // as std::slice::Windows<[u8;4]>;
-    // as &Iterator<Item=&[u8; 4]>;
-    /*
-    for c in numbers {
-        println!("c: {}   {}", read_number_i32(c), read_number_f32(c));
-        println!("cr: {:?}", c);
-    }
-    */
-
-    //if let Some(iter) = numbers {
-    let _pages = read_pages(&mut numbers, max_size_file);
-    //} else {
-    //    let pages = Vec::<Page>::default();
-    //}
-
-    // .map(|x|read_next(&x, & mut pc));
-    // .collect::<Vec<_>>();
-
-    // println!("{:?}", &numbers[..200]);
+    println!("\ndone. read {} pages.", pages.len());
 }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -119,7 +119,6 @@ pub fn read_layers(cursor: &mut Cursor<&[u8]>, _max_size_file: usize) -> Vec<Lay
     layers
 }
 
-// bytes: &[u8]
 pub fn read_pages(content: &[u8], _max_size_file: usize) -> Vec<Page> {
     let mut cursor = Cursor::new(content);
 

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1,0 +1,134 @@
+use byteorder::{LittleEndian, ReadBytesExt};
+use std::io::Cursor;
+use std::io::Read;
+use crate::*;
+
+#[test]
+fn test_read_number_i32() {
+    let num = read_number_i32(&[42, 0, 0, 0]);
+    assert_eq!(42, num);
+}
+
+pub fn read_number_i32(bytes: &[u8]) -> i32 {
+    let mut rdr = Cursor::new(&bytes[0..4]);
+    // TODO implement if let Some(...)
+    let number = rdr.read_i32::<LittleEndian>().unwrap();
+    number
+}
+
+pub fn read_number_f32(bytes: &[u8]) -> f32 {
+    let mut rdr = Cursor::new(&bytes[0..4]);
+    // TODO implement if let Some(...)
+    let number = rdr.read_f32::<LittleEndian>().unwrap();
+    number
+}
+
+pub fn parse_line_header(cursor: &mut Cursor<&[u8]>) -> Option<(i32, i32, i32, f32)> {
+    let mut brush_type = [0u8; 4];
+    let mut color = [0u8; 4];
+    let mut unknown_line_attribute = [0u8; 4];
+    let mut brush_base_size = [0u8; 4];
+
+    cursor.read_exact(&mut brush_type).ok()?;
+    cursor.read_exact(&mut color).ok()?;
+    cursor.read_exact(&mut unknown_line_attribute).ok()?;
+    cursor.read_exact(&mut brush_base_size).ok()?;
+
+    // TODO verify range of values
+    return Some((
+        read_number_i32(&brush_type),
+        read_number_i32(&color),
+        read_number_i32(&unknown_line_attribute),
+        read_number_f32(&brush_base_size),
+    ));
+}
+
+pub fn parse_point_header(cursor: &mut Cursor<&[u8]>) -> Option<(f32, f32, f32, f32, f32, f32)> {
+    let mut x = [0u8; 4];
+    let mut y = [0u8; 4];
+    let mut speed = [0u8; 4];
+    let mut direction = [0u8; 4];
+    let mut width = [0u8; 4];
+    let mut pressure = [0u8; 4];
+
+    cursor.read_exact(&mut x).ok()?;
+    cursor.read_exact(&mut y).ok()?;
+    cursor.read_exact(&mut speed).ok()?;
+    cursor.read_exact(&mut direction).ok()?;
+    cursor.read_exact(&mut width).ok()?;
+    cursor.read_exact(&mut pressure).ok()?;
+
+    return Some((
+        read_number_f32(&x),
+        read_number_f32(&y),
+        read_number_f32(&speed),
+        read_number_f32(&direction),
+        read_number_f32(&width),
+        read_number_f32(&pressure),
+    ));
+}
+
+pub fn read_points(cursor: &mut Cursor<&[u8]>, _max_size_file: usize) -> Vec<Point> {
+    let mut points = Vec::<Point>::default();
+    let mut num_points = [0u8; 4];
+    if let Ok(()) = cursor.read_exact(&mut num_points) {
+        for _pt in 0..read_number_i32(&num_points) {
+            println!("pt: {} / {}", _pt, read_number_i32(&num_points));
+            if let Some(tuple) = parse_point_header(cursor) {
+                let new_point = Point::new(tuple);
+                points.push(new_point);
+            } else {
+                break;
+            }
+        }
+    }
+    points
+}
+
+pub fn read_lines(cursor: &mut Cursor<&[u8]>, _max_size_file: usize) -> Vec<Line> {
+    let mut lines = vec![];
+    let mut num_lines = [0u8; 4];
+    if let Ok(()) = cursor.read_exact(&mut num_lines) {
+        for _li in 0..read_number_i32(&num_lines) {
+            println!("li: {} / {}", _li, read_number_i32(&num_lines));
+            if let Some(tuple) = parse_line_header(cursor) {
+                println!("new line!");
+                let new_line = Line::new(tuple, read_points(cursor, _max_size_file));
+                lines.push(new_line);
+                println!("new line done!");
+            } else {
+                break;
+            }
+        }
+    }
+    lines
+}
+
+pub fn read_layers(cursor: &mut Cursor<&[u8]>, _max_size_file: usize) -> Vec<Layer> {
+    let mut layers = vec![];
+    let mut num_layers = [0u8; 4];
+    if let Ok(()) = cursor.read_exact(&mut num_layers) {
+        for _l in 0..read_number_i32(&num_layers) {
+            println!("l: {} / {}", _l, read_number_i32(&num_layers));
+            let new_layer = Layer {
+                lines: read_lines(cursor, _max_size_file),
+            };
+            layers.push(new_layer);
+        }
+    }
+    layers
+}
+
+// bytes: &[u8]
+pub fn read_pages(content: &[u8], _max_size_file: usize) -> Vec<Page> {
+    let mut cursor = Cursor::new(content);
+
+    let mut pages = vec![];
+    let num_pages = 1;
+    println!("p: 0 / {}", num_pages);
+    let new_page = Page {
+        layers: read_layers(&mut cursor, _max_size_file),
+    };
+    pages.push(new_page);
+    pages
+}

--- a/src/render.rs
+++ b/src/render.rs
@@ -1,0 +1,42 @@
+use pdf_canvas::graphicsstate::{Color, Matrix, CapStyle, JoinStyle};
+use pdf_canvas::Pdf;
+use crate::*;
+
+const BASE_LINE_WIDTH: f32 = 4.;
+
+/// Create a `mandala.pdf` file.
+pub fn render(path: &str, pages: &[Page]) {
+    // Open our pdf document.
+    let mut document = Pdf::create(path).expect("Create PDF file");
+
+    // Only one page to consider.
+    let page = &pages[0];
+
+    // Render a page with something resembling a mandala on it.
+    document
+        .render_page(1404.0, 1872.0, |c| {
+            // Inverse Y coordinate system.
+            c.concat(Matrix::scale(1., -1.))?;
+            c.concat(Matrix::translate(0., -1872.))?;
+
+            c.set_stroke_color(Color::gray(0))?;
+
+            for layer in &page.layers {
+                for line in &layer.lines {
+                    let first_point = &line.points[0];
+                    c.move_to(first_point.x, first_point.y)?;
+                    for point in &line.points {
+                        c.set_line_width(point.pressure * BASE_LINE_WIDTH)?;
+                        c.set_line_cap_style(CapStyle::Round)?;
+                        c.set_line_join_style(JoinStyle::Round)?;
+                        c.line_to(point.x, point.y,)?;
+                    }
+                    c.stroke()?;
+                }
+            }
+
+            Ok(())
+        })
+        .unwrap();
+    document.finish().unwrap();
+}


### PR DESCRIPTION
Glad to see a crate for remarkable existed! I spent a few hours hacking on this and wound up with a pretty big PR:

* Lets you pass in arguments, i.e. a filename to read
* Upgrades to edition 2018
* Splits out main.rs and lib.rs
* Use Cursor instead of Chunks iterator
* Runs rustfmt
* Adds support for rendering to PDFs (with basic pressure sensitivity)