### PR TITLE
Rounded line joins for SVG's and a few minor changes to support use as a library

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 pub mod render {
-    pub mod svg;
     pub mod pdf;
     pub mod renderlib;
+    pub mod svg;
 }
 pub mod parse {
     pub mod parse_lines;
@@ -149,7 +149,8 @@ impl Line {
     }
 
     fn length(&self) -> f32 {
-        self.points.iter()
+        self.points
+            .iter()
             .zip(self.points[1..].iter())
             .map(|(previous_point, point)| previous_point.distance(point))
             .sum()
@@ -407,4 +408,12 @@ fn test_matrix_point_mul() {
 
 pub struct LayerColors {
     pub colors: Vec<(String, String, String)>,
+}
+
+impl Default for LayerColors {
+    fn default() -> Self {
+        Self {
+            colors: vec![("black".to_string(), "grey".to_string(), "white".to_string())],
+        }
+    }
 }

--- a/src/render/renderlib.rs
+++ b/src/render/renderlib.rs
@@ -46,9 +46,11 @@ impl BoundingBox {
 
 pub fn line_to_css_color<'a>(
     line: &Line,
-    layer_id: usize,
+    mut layer_id: usize,
     layer_colors: &'a LayerColors,
 ) -> &'a str {
+    // If no layer color is provided for this layer, default to the last layer we have colors for.
+    layer_id = layer_id.min(layer_colors.colors.len() - 1);
     match line.brush_type {
         BrushType::Highlighter => "rgb(240, 220, 40)",
         _ => match line.color {

--- a/src/render/svg.rs
+++ b/src/render/svg.rs
@@ -20,6 +20,7 @@ pub fn render_constant_width_line(
         .set("fill", "none")
         .set("d", data)
         .set("color", css_color)
+        .set("stroke-linejoin", "round")
         .set("stroke", "currentColor")
         .set("class", format!("{:#?}", line.brush_type));
 
@@ -28,7 +29,6 @@ pub fn render_constant_width_line(
             path = path
                 .set("stroke-width", first_point.width)
                 .set("stroke-linecap", "butt")
-                .set("stroke-linejoin", "round")
                 .set("stroke-opacity", 0.25);
         }
         _ => {

--- a/src/render/svg.rs
+++ b/src/render/svg.rs
@@ -28,6 +28,7 @@ pub fn render_constant_width_line(
             path = path
                 .set("stroke-width", first_point.width)
                 .set("stroke-linecap", "butt")
+                .set("stroke-linejoin", "round")
                 .set("stroke-opacity", 0.25);
         }
         _ => {


### PR DESCRIPTION
Lines generated currently are spiky due to the default linejoin attribute, switching it to round improves things:

![svgs-join-spikes](https://user-images.githubusercontent.com/1832378/115159472-3ec06480-a061-11eb-8228-42ea1e088762.gif)
