### PR TITLE
Rendering Fidelity

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -47,6 +47,13 @@ fn main() -> Result<()> {
                 .possible_values(&["svg", "pdf"])
         )
         .arg(
+            Arg::with_name("distance-threshold")
+                .long("distance-threshold")
+                .takes_value(true)
+                .help("Threshold of distance between points, lower values produce higher fidelity renderings at the cost of file sizes")
+                .default_value("2.0")
+        )
+        .arg(
             Arg::with_name("debug-dump")
             .short("d")
             .long("debug-dump")
@@ -90,6 +97,12 @@ fn main() -> Result<()> {
             .collect(),
     };
 
+    let distance_threshold: f32 = matches
+        .value_of("distance-threshold")
+        .expect("Failed to read distance threshold")
+        .parse()
+        .expect("Distance threshold not a valud f32");
+
     let debug_dump = matches.is_present("debug-dump");
     if debug_dump && (output_type != OutputType::Svg) {
         eprintln!("Warning: debug-dump only has an effect when writing SVG output");
@@ -100,6 +113,7 @@ fn main() -> Result<()> {
         output_filename,
         layer_colors,
         auto_crop,
+        distance_threshold,
         debug_dump,
     };
 
@@ -144,6 +158,7 @@ fn process_single_file(
             &lines_data.pages[0],
             opts.auto_crop,
             &opts.layer_colors,
+            opts.distance_threshold,
             opts.debug_dump,
         )
         .context("failed to write SVG")?,
@@ -170,5 +185,6 @@ struct Options<'a> {
     output_filename: Option<&'a str>,
     layer_colors: LayerColors,
     auto_crop: bool,
+    distance_threshold: f32,
     debug_dump: bool,
 }

--- a/src/render/svg.rs
+++ b/src/render/svg.rs
@@ -9,10 +9,16 @@ pub fn render_constant_width_line(
     css_color: &str,
     debug_dump: bool,
 ) -> svg::node::element::Path {
-    let first_point = &line.points[0];
+    let mut point_iter = line.points.iter();
+
+    let first_point = if let Some(p) = point_iter.next() {
+        p
+    } else {
+        return svg::node::element::Path::new();
+    };
 
     let mut data = svg::node::element::path::Data::new().move_to((first_point.x, first_point.y));
-    for point in line.points.iter() {
+    for point in point_iter {
         data = data.line_to((point.x, point.y));
     }
 

--- a/src/render/svg.rs
+++ b/src/render/svg.rs
@@ -7,19 +7,26 @@ const WIDTH_FACTOR: f32 = 0.8;
 pub fn render_constant_width_line(
     line: &Line,
     css_color: &str,
+    distance_threshold: f32,
     debug_dump: bool,
 ) -> svg::node::element::Path {
-    let mut point_iter = line.points.iter();
+    let mut point_iter = line.points.iter().enumerate();
 
-    let first_point = if let Some(p) = point_iter.next() {
+    let mut prev_point = if let Some((_, p)) = point_iter.next() {
         p
     } else {
         return svg::node::element::Path::new();
     };
 
-    let mut data = svg::node::element::path::Data::new().move_to((first_point.x, first_point.y));
-    for point in point_iter {
+    let mut data = svg::node::element::path::Data::new().move_to((prev_point.x, prev_point.y));
+    for (idx, point) in point_iter {
+        let dist = point - prev_point;
+        let is_last_point = idx + 1 == line.points.len();
+        if dist.length() < distance_threshold && !is_last_point {
+            continue;
+        }
         data = data.line_to((point.x, point.y));
+        prev_point = point;
     }
 
     let mut path = svg::node::element::Path::new()
@@ -33,13 +40,13 @@ pub fn render_constant_width_line(
     match line.brush_type {
         BrushType::Highlighter => {
             path = path
-                .set("stroke-width", first_point.width)
+                .set("stroke-width", prev_point.width)
                 .set("stroke-linecap", "butt")
                 .set("stroke-opacity", 0.25);
         }
         _ => {
             path = path
-                .set("stroke-width", first_point.width * WIDTH_FACTOR)
+                .set("stroke-width", prev_point.width * WIDTH_FACTOR)
                 .set("stroke-linecap", "round");
         }
     }
@@ -54,6 +61,7 @@ pub fn render_constant_width_line(
 pub fn render_variable_width_line(
     line: &Line,
     css_color: &str,
+    distance_threshold: f32,
     debug_dump: bool,
 ) -> svg::node::element::Group {
     let mut stroke_group = svg::node::element::Group::new()
@@ -63,11 +71,27 @@ pub fn render_variable_width_line(
         .set("stroke-linecap", "round")
         .set("class", format!("{:#?}", line.brush_type));
 
-    for (previous_index, point) in line.points[1..].iter().enumerate() {
-        let prev_point = &line.points[previous_index];
+    let mut point_iter = line.points.iter().enumerate();
+
+    let mut prev_point = if let Some((_, p)) = point_iter.next() {
+        p
+    } else {
+        return svg::node::element::Group::new();
+    };
+
+    for (idx, point) in point_iter {
+        let dist = point - prev_point;
+        let is_last_point = idx + 1 == line.points.len();
+        if dist.length() < distance_threshold && !is_last_point {
+            continue;
+        }
+
         let data = svg::node::element::path::Data::new()
             .move_to((prev_point.x, prev_point.y))
             .line_to((point.x, point.y));
+
+        prev_point = point;
+
         let opacity = match line.brush_type {
             BrushType::BallPoint => point.pressure.powf(5.0) + 0.7,
             _ => 1.0,
@@ -94,28 +118,34 @@ pub fn render_svg(
     page: &Page,
     auto_crop: bool,
     layer_colors: &LayerColors,
+    distance_threshold: f32,
     debug_dump: bool,
 ) -> io::Result<()> {
     let mut doc = svg::Document::new();
     for (layer_id, layer) in page.layers.iter().enumerate() {
         let mut layer_group = svg::node::element::Group::new().set("class", "layer");
         for line in layer.lines.iter() {
-            if line.points.is_empty() {
-                continue;
-            }
             let css_color = line_to_css_color(line, layer_id, layer_colors);
-            match line.brush_type {
+            match &line.brush_type {
                 BrushType::Highlighter | BrushType::Fineliner => {
-                    layer_group =
-                        layer_group.add(render_constant_width_line(line, css_color, debug_dump))
+                    layer_group = layer_group.add(render_constant_width_line(
+                        line,
+                        css_color,
+                        distance_threshold,
+                        debug_dump,
+                    ))
                 }
                 BrushType::EraseArea
                 | BrushType::Eraser
                 | BrushType::EraseAll
                 | BrushType::SelectionBrush => (),
                 _ => {
-                    layer_group =
-                        layer_group.add(render_variable_width_line(line, css_color, debug_dump))
+                    layer_group = layer_group.add(render_variable_width_line(
+                        line,
+                        css_color,
+                        distance_threshold,
+                        debug_dump,
+                    ))
                 }
             }
         }


### PR DESCRIPTION
adds a `--distance-threshold` option for reducing fidelity of the generated SVG.

The effect is most pronounced on notebooks with small details such as written text.

|`--distance-threshold=`| 0 | 2 | 10 | 20 |
|-| -------------|--------------| ------|-|
|text e.g.| ![thresh-0](https://user-images.githubusercontent.com/1832378/141655091-45f2f292-9d7f-47dd-b704-900bfca63612.png) | ![thresh-2](https://user-images.githubusercontent.com/1832378/141655323-396ca973-ecd3-4cfd-a636-fe72ba6d0ca8.png) |![thresh-10](https://user-images.githubusercontent.com/1832378/141655367-46185b9d-9abf-4f6d-902d-fdd615555a16.png)|![thresh-20](https://user-images.githubusercontent.com/1832378/141655538-0dac0bd6-cf88-4995-bf7e-b78456449a30.png)|
|svg size| 1.4M | 504K | 164K | 116K ||
|head e.g.|![head-0](https://user-images.githubusercontent.com/1832378/141655658-572c124e-bf74-4e2f-be7e-ebe0d12ee5f2.png)|![head-2](https://user-images.githubusercontent.com/1832378/141655745-22cf69af-a3d3-4baf-a427-467bf8044c07.png)|![head-10](https://user-images.githubusercontent.com/1832378/141655768-e9c1057a-b101-41e4-a636-5add7a806431.png)|![head-20](https://user-images.githubusercontent.com/1832378/141655789-c85ff642-8833-4f7c-8dc3-216a4f084734.png)|
|svg size|580K|504K|356K|300K|



