### PR TITLE
Add support for the new red/blue export colors

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(iter_intersperse)]
-
 pub mod render {
     pub mod pdf;
     pub mod renderlib;
@@ -27,7 +25,7 @@ pub enum Error {
     #[error("Unknown color: {0}")]
     UnknownColor(i32),
 
-    #[error("Unknown template: '{0}' Valid templates are:\n  {}", crate::render::templates::TEMPLATES.keys().copied().intersperse("\n  ").collect::<String>())]
+    #[error("Unknown template: '{0}' Valid templates are:\n  {}", crate::render::templates::TEMPLATES.keys().copied().map(|t| format!("\n  {}", t)).collect::<String>())]
     UnknownTemplate(String),
 
     #[error("Invalid Segment index: {0}")]
@@ -118,6 +116,8 @@ pub enum Color {
     Black,
     Grey,
     White,
+    Blue,
+    Red,
 }
 
 impl TryFrom<i32> for Color {
@@ -128,6 +128,8 @@ impl TryFrom<i32> for Color {
             0 => Ok(Color::Black),
             1 => Ok(Color::Grey),
             2 => Ok(Color::White),
+            6 => Ok(Color::Blue),
+            7 => Ok(Color::Red),
             _ => Err(Error::UnknownColor(color_i)),
         }
     }
@@ -413,14 +415,23 @@ fn test_matrix_point_mul() {
     assert_eq!([10.0, 14.0], m * p);
 }
 
-pub struct LayerColors {
-    pub colors: Vec<(String, String, String)>,
+#[derive(Clone)]
+pub struct LayerColor {
+    pub black: String,
+    pub grey: String,
+    pub white: String,
+    pub blue: String,
+    pub red: String,
 }
 
-impl Default for LayerColors {
+impl Default for LayerColor {
     fn default() -> Self {
         Self {
-            colors: vec![("black".to_string(), "grey".to_string(), "white".to_string())],
+            black: "black".to_string(),
+            grey: "#bfbfbf".to_string(),
+            white: "white".to_string(),
+            blue: "#0062cc".to_string(),
+            red: "#d90707".to_string(),
         }
     }
 }

--- a/src/render/renderlib.rs
+++ b/src/render/renderlib.rs
@@ -1,4 +1,4 @@
-use crate::{BrushType, Color, LayerColors, Line, Page, Point};
+use crate::{BrushType, Color, LayerColor, Line, Page, Point};
 use core::f32::{INFINITY, NEG_INFINITY};
 
 pub(crate) struct BoundingBox {
@@ -44,19 +44,17 @@ impl BoundingBox {
     }
 }
 
-pub fn line_to_css_color<'a>(
-    line: &Line,
-    mut layer_id: usize,
-    layer_colors: &'a LayerColors,
-) -> &'a str {
+pub fn line_to_css_color(line: &Line, layer_idx: usize, layer_colors: &[LayerColor]) -> String {
     // If no layer color is provided for this layer, default to the last layer we have colors for.
-    layer_id = layer_id.min(layer_colors.colors.len() - 1);
+    let layer_colors = layer_colors.get(layer_idx).cloned().unwrap_or_default();
     match line.brush_type {
-        BrushType::Highlighter => "rgb(240, 220, 40)",
+        BrushType::Highlighter => "rgb(240, 220, 40)".to_string(),
         _ => match line.color {
-            Color::Black => &layer_colors.colors[layer_id].0,
-            Color::Grey => &layer_colors.colors[layer_id].1,
-            Color::White => &layer_colors.colors[layer_id].2,
+            Color::Black => layer_colors.black,
+            Color::Grey => layer_colors.grey,
+            Color::White => layer_colors.white,
+            Color::Blue => layer_colors.blue,
+            Color::Red => layer_colors.red,
         },
     }
 }

--- a/src/render/svg.rs
+++ b/src/render/svg.rs
@@ -1,6 +1,6 @@
 use crate::render::renderlib::{line_to_css_color, BoundingBox};
 use crate::render::templates;
-use crate::{BrushType, LayerColors, Line, Page, Result};
+use crate::{BrushType, LayerColor, Line, Page, Result};
 use std::io;
 
 const WIDTH_FACTOR: f32 = 0.8;
@@ -118,7 +118,7 @@ pub fn render_svg(
     output: &mut dyn io::Write,
     page: &Page,
     auto_crop: bool,
-    layer_colors: &LayerColors,
+    layer_colors: &[LayerColor],
     distance_threshold: f32,
     template: Option<&str>,
     debug_dump: bool,
@@ -132,7 +132,7 @@ pub fn render_svg(
                 BrushType::Highlighter | BrushType::Fineliner => {
                     layer_group = layer_group.add(render_constant_width_line(
                         line,
-                        css_color,
+                        &css_color,
                         distance_threshold,
                         debug_dump,
                     ))
@@ -144,7 +144,7 @@ pub fn render_svg(
                 _ => {
                     layer_group = layer_group.add(render_variable_width_line(
                         line,
-                        css_color,
+                        &css_color,
                         distance_threshold,
                         debug_dump,
                     ))
@@ -167,10 +167,10 @@ pub fn render_svg(
             .set("width", width)
             .set("height", height);
     } else {
-        let width = 1404;
-        let height = 1872;
+        let width = 1404i16;
+        let height = 1872i16;
         doc = doc
-            .set("viewBox", (0, 0, width, height))
+            .set("viewBox", (0i8, 0i8, width, height))
             .set("width", width)
             .set("height", height);
     }


### PR DESCRIPTION
Adds support for the new red/blue colors:

![lines-are-rusty-red-blue-colors](https://user-images.githubusercontent.com/1832378/145723202-05d119ff-ac72-4655-b23e-0f7fac3787e4.png)
